### PR TITLE
allow mail relay to skip auth

### DIFF
--- a/templates/nullmailer_remotes
+++ b/templates/nullmailer_remotes
@@ -1,1 +1,1 @@
-{{ nullmailer_relay_host }} smtp --port={{ nullmailer_relay_port }} --auth-login --user={{ nullmailer_relay_user }} --pass={{ nullmailer_relay_pass }}{% if nullmailer_remote_ssl %} --ssl{% endif %}{% if nullmailer_remote_starttls %} --starttls{% endif %}
+{{ nullmailer_relay_host }} smtp --port={{ nullmailer_relay_port }}{% if nullmailer_relay_user %} --auth-login --user={{ nullmailer_relay_user }} --pass={{ nullmailer_relay_pass }}{% endif %}{% if nullmailer_remote_ssl %} --ssl{% endif %}{% if nullmailer_remote_starttls %} --starttls{% endif %}


### PR DESCRIPTION
This PR updates the current config so that authentication will be skipped if nullmailer_relay_user is empty.

Public relays, of course, would not use this. But it may be required for cases where permission is based on the IP address range of a closed network. 